### PR TITLE
Fix ring-genfiles

### DIFF
--- a/src/main/clojure/zi/ring_genfiles.clj
+++ b/src/main/clojure/zi/ring_genfiles.clj
@@ -73,10 +73,10 @@ The code is based on the
      [:web-app
       (when (or init destroy)
         [:listener
-         [:listener-class listener-class]])
+         [:listener-class (string/replace listener-class "-" "_")]])
       [:servlet
        [:servlet-name  handler]
-       [:servlet-class servlet-class]]
+       [:servlet-class (string/replace servlet-class "-" "_")]]
       [:servlet-mapping
        [:servlet-name handler ]
        [:url-pattern (or url-pattern "/*")]]])))


### PR DESCRIPTION
listener-class and servlet-class in web.xml should point to the class file.
Currently, if we have a servlet like 'toto-blah.servlet' the content in the web.xml will be 'toto-blah.servlet', which is incorrect. It should be 'toto_blah.servlet'.
