### PR TITLE
Allow defmethods for test-report

### DIFF
--- a/src/main/clojure/zi/test.clj
+++ b/src/main/clojure/zi/test.clj
@@ -60,6 +60,8 @@
              `(fn [out# err#]
                 (clojure.main/with-bindings
                   (binding [*out* out# *err* err#]
+                    (binding [clojure.test/*test-out* *out*]
+                      (require ~@test-ns-symbols))
                     (let [results# (atom [])
                           original-report# clojure.test/report
                           report# (fn [m#]
@@ -76,7 +78,6 @@
                       (~'portable-redef
                        [clojure.test/report report#]
                        (binding [clojure.test/*test-out* *out*]
-                         (require ~@test-ns-symbols)
                          (clojure.test/run-tests ~@test-ns-symbols)))
                       (map #(update-in % [:message] str) @results#)))))
              *out* *err*)

--- a/src/main/clojure/zi/test.clj
+++ b/src/main/clojure/zi/test.clj
@@ -60,8 +60,7 @@
              `(fn [out# err#]
                 (clojure.main/with-bindings
                   (binding [*out* out# *err* err#]
-                    (binding [clojure.test/*test-out* *out*]
-                      (require ~@test-ns-symbols))
+                      
                     (let [results# (atom [])
                           original-report# clojure.test/report
                           report# (fn [m#]
@@ -75,6 +74,7 @@
                                           [:ns] #(when %
                                                    (list
                                                     `quote (ns-name %)))))))]
+                      (require ~@test-ns-symbols)
                       (~'portable-redef
                        [clojure.test/report report#]
                        (binding [clojure.test/*test-out* *out*]


### PR DESCRIPTION
Hi hugo,

Some test frameworks, such as midje register aditionnal defmethods, by requiring after the test-report symbol has been redefed to a function, the registrations fail.

This PR moves the requires before the redefinition of symbols and keep the actual reporting inside the redefinition.
