### PR TITLE
fix handler-source which was not returning wished fn

### DIFF
--- a/src/main/clojure/zi/ring_genfiles.clj
+++ b/src/main/clojure/zi/ring_genfiles.clj
@@ -49,8 +49,7 @@ The code is based on the
      (~handler-sym
       (assoc request#
         :path-info (.getPathInfo (:servlet-request request#))
-        :context (.getContextPath (:servlet-request request#)))))
-  handler-sym)
+        :context (.getContextPath (:servlet-request request#))))))
 
 ;; Adapted from the lein-ring plugin
 (defn servlet-source


### PR DESCRIPTION
This fix a bug in ring-genfiles which could lead to issues with routes.
Specified handler was unaware of context & path info.
